### PR TITLE
Require edit mode before brush drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ With your toolbar active, classification becomes effortless:
 
 Activate the brush tool for photoshop-style polygon creation:
 
+**Note:** The brush tool requires the target layer to be in editing mode. If the layer isn't editable, drawing will warn and abort.
+
 - **Left-click + drag**: Paint polygons
 - **Right-click + drag**: Erase areas
 - **Shift + scroll**: Adjust brush size

--- a/drawmybrush.py
+++ b/drawmybrush.py
@@ -334,6 +334,13 @@ class DrawByBrush:
         # Get current active layer used in the drawing tool
         self.active_layer = self.tool.active_layer
 
+        # Require layer to already be in edit mode
+        if not self.active_layer.isEditable():
+            self.iface.messageBar().pushWarning(
+                "Brush", "Target layer is not editable. Enable editing mode to draw."
+            )
+            return
+
         # Create new feature
         new_feature = QgsFeature(self.active_layer.fields())
         new_feature.setGeometry(emmitted_geometry)
@@ -363,8 +370,6 @@ class DrawByBrush:
                     self.active_layer.deleteFeature(f.id())
             
             # Wrap in edit command for proper undo/redo support
-            if not self.active_layer.isEditable():
-                self.active_layer.startEditing()
             self.active_layer.beginEditCommand("Brush add")
             ok = self.active_layer.addFeature(new_feature)
             if not ok:

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import types
+
+# Stub out QGIS modules required for importing drawmybrush
+qgis = types.ModuleType("qgis")
+PyQt = types.ModuleType("qgis.PyQt")
+QtCore = types.ModuleType("qgis.PyQt.QtCore")
+QtGui = types.ModuleType("qgis.PyQt.QtGui")
+QtWidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+core = types.ModuleType("qgis.core")
+
+class Dummy:
+    pass
+
+for mod, names in [
+    (QtCore, ["QSettings", "QTranslator", "QCoreApplication", "Qt"]),
+    (QtGui, ["QIcon", "QColor", "QPixmap", "QCursor", "QGuiApplication"]),
+    (QtWidgets, ["QAction"]),
+]:
+    for name in names:
+        setattr(mod, name, Dummy)
+
+for name in [
+    "QgsFeature",
+    "QgsProject",
+    "QgsGeometry",
+    "QgsVectorLayer",
+    "QgsRenderContext",
+    "QgsLayerTreeGroup",
+    "QgsWkbTypes",
+    "QgsMapLayer",
+]:
+    setattr(core, name, type(name, (), {}))
+
+class QgsExpressionContextUtils:
+    @staticmethod
+    def globalProjectLayerScopes(layer):
+        return None
+
+core.QgsExpressionContextUtils = QgsExpressionContextUtils
+
+qgis.PyQt = PyQt
+qgis.core = core
+
+sys.modules.setdefault("qgis", qgis)
+sys.modules.setdefault("qgis.PyQt", PyQt)
+sys.modules.setdefault("qgis.PyQt.QtCore", QtCore)
+sys.modules.setdefault("qgis.PyQt.QtGui", QtGui)
+sys.modules.setdefault("qgis.PyQt.QtWidgets", QtWidgets)
+sys.modules.setdefault("qgis.core", core)
+
+# Now import the module under test within a fake package to satisfy relative imports
+root = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, root)
+
+pkg = types.ModuleType("class_labeler")
+pkg.__path__ = [root]
+sys.modules.setdefault("class_labeler", pkg)
+sys.modules.setdefault("class_labeler.resources", types.ModuleType("resources"))
+brushtools_mod = types.ModuleType("brushtools")
+brushtools_mod.BrushTool = type("BrushTool", (), {})
+sys.modules.setdefault("class_labeler.brushtools", brushtools_mod)
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("class_labeler.drawmybrush", os.path.join(root, "drawmybrush.py"))
+drawmybrush = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("class_labeler.drawmybrush", drawmybrush)
+spec.loader.exec_module(drawmybrush)
+
+
+def test_draw_requires_edit_mode():
+    warnings = []
+
+    class MessageBar:
+        def pushWarning(self, title, message):
+            warnings.append((title, message))
+
+    class Iface:
+        def messageBar(self):
+            return MessageBar()
+
+    class Layer:
+        def __init__(self):
+            self.editable = False
+            self.start_called = False
+
+        def isEditable(self):
+            return self.editable
+
+        def startEditing(self):
+            self.start_called = True
+
+    iface = Iface()
+    layer = Layer()
+    tool = types.SimpleNamespace(active_layer=layer, drawing_mode="drawing", merging=False)
+
+    plugin = types.SimpleNamespace(iface=iface, tool=tool)
+
+    drawmybrush.DrawByBrush.draw(plugin, None)
+
+    assert warnings, "Expected warning when layer is not editable"
+    assert not layer.start_called, "startEditing should not be invoked"


### PR DESCRIPTION
## Summary
- guard brush drawing with an edit-mode check and warn if the layer isn't editable
- document the need to manually enable editing before using the brush tool
- add a unit test confirming the brush won't start editing automatically

## Testing
- `python -m py_compile drawmybrush.py tests/test_draw.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0209b40808329b9020d048b7a35a0